### PR TITLE
Run arm64 builds natively.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,16 +4,20 @@ ARG go_tag_suffix=-alpine
 
 
 FROM --platform=$TARGETPLATFORM ${go_registry}golang:${go_version}${go_tag_suffix} AS builder
-ARG TARGETARCH TARGETOS
-ARG GOARCH=$TARGETARCH GOOS=$TARGETOS
+ARG TARGETARCH
+ARG TARGETOS
+ARG GOARCH=$TARGETARCH
+ARG GOOS=$TARGETOS
 ARG CGO_ENABLED=0
+ARG GOFLAGS="-trimpath"
+ARG go_ldflags="-s -w"
 
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . ./
-RUN go build -o /bin/govuk-exporter main.go
+RUN go build -o /bin/govuk-exporter -ldflags="$go_ldflags" main.go
 
 
 FROM --platform=$TARGETPLATFORM scratch

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG go_version=1.22
 ARG go_tag_suffix=-alpine
 
 
-FROM ${go_registry}golang:${go_version}${go_tag_suffix} AS builder
+FROM --platform=$TARGETPLATFORM ${go_registry}golang:${go_version}${go_tag_suffix} AS builder
 ARG TARGETARCH TARGETOS
 ARG GOARCH=$TARGETARCH GOOS=$TARGETOS
 ARG CGO_ENABLED=0
@@ -16,7 +16,7 @@ COPY . ./
 RUN go build -o /bin/govuk-exporter main.go
 
 
-FROM scratch
+FROM --platform=$TARGETPLATFORM scratch
 COPY --from=builder /bin/govuk-exporter /bin/govuk-exporter
 COPY --from=builder /usr/share/ca-certificates /usr/share/ca-certificates
 COPY --from=builder /etc/ssl /etc/ssl


### PR DESCRIPTION
In principle we could just cross-build from a single runner (because the Go toolchain is awesome), but it's less hassle to just do the same thing we do for the Ruby builds where we don't cross-compile.

Tested: builds locally.

#10