### PR TITLE
Couple of fixes for calling the new deploy.yml workflow.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,6 @@ on:
         description: 'Commit, tag or branch name to deploy'
         required: true
         type: string
-        default: 'main'
       environment:
         description: 'Environment to deploy to'
         required: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,6 @@
 name: Deploy
 
-run-name: Deploy ${{ inputs.gitRef || github.ref_name  }} to ${{ inputs.environment || 'integration' }}
+run-name: Deploy ${{ inputs.gitRef || github.event.release.tag_name  }} to ${{ inputs.environment || 'integration' }}
 
 on:
   workflow_dispatch:
@@ -23,11 +23,11 @@ on:
 
 jobs:
   build-and-publish-image:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref_name, 'v')
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'v')
     name: Build and publish image
     uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-multiarch-image.yml@main
     with:
-      gitRef: ${{ inputs.gitRef || github.ref_name }}
+      gitRef: ${{ inputs.gitRef || github.event.release.tag_name }}
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
- Remove leftover default param that made it easy to accidentally build+deploy `main`. Makes it the same as all the other repos.
- Make the tag refs work the same as all the other repos.

Turns out I picked the one repo that had an outdated version of these boilerplate workflow-calling workflows. Sigh.

#10