### PR TITLE
Add error message for non-200 status codes

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"net/http"
 	"os"
 	"time"
@@ -57,6 +58,10 @@ func fetchMirrorFreshnessMetric(backend string, url string) (float64, error) {
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		return -1, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return -1, fmt.Errorf("request failed with status code: %s", resp.Status)
 	}
 
 	lastModified := resp.Header.Get("Last-Modified")


### PR DESCRIPTION
If the request is not sucessful we confusingly get a time parse error (because there is no Last-Modified header and string to parse). This makes it more explicit when the exporter is failing due to a non-200 response.